### PR TITLE
feat: Add version information middleware 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem "railties", "~> 8.0.1"
 gem "rubocop-rails-omakase", require: false
 
 gem "dotenv-rails", require: "dotenv/load"
+
+gem "mocha", "~> 2.7"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Rails AppVersion
 
-Rails AppVersion provides seamless version and environment management for your Rails applications. By exposing version and environment information throughout your application, it enables better error tracking, debugging, and deployment management.
+Rails AppVersion provides an opinionated version and environment management for your Rails applications. By exposing
+version and environment information throughout your application, it enables better error tracking, debugging, and
+deployment management.
 
 ## Why Use Rails AppVersion?
 
-Version and environment tracking are crucial for modern web applications, particularly when debugging issues in production. Rails AppVersion helps you:
+Version and environment tracking are important for modern web applications, particularly when debugging issues in
+production. Rails AppVersion helps you:
 
 - Track errors with version context in error reporting services
 - Identify which version of your application is running in each environment
 - Cache bust assets between versions
 - Verify deployment success across environments
+- Avoid homegrown version management solutions
 
 ### Error Reporting Integration Example
 
@@ -23,6 +27,7 @@ end
 ### Cache Management Example
 
 ```ruby
+
 class AssetManifest
   def asset_path(path)
     "/assets/#{path}?v=#{Rails.application.version.to_cache_key}"
@@ -52,7 +57,8 @@ Rails AppVersion supports two methods for managing your application's version:
 
 ### Recommended: Using a VERSION File
 
-The recommended approach is to maintain a `VERSION` file in your application's root directory. This file should contain only the version number:
+The recommended approach is to maintain a `VERSION` file in your application's root directory. This file should contain
+only the version number:
 
 ```plaintext
 # VERSION
@@ -60,6 +66,7 @@ The recommended approach is to maintain a `VERSION` file in your application's r
 ```
 
 This approach offers several advantages:
+
 - Clear version history in source control
 - Easy automated updates during deployment
 - Separation of version from configuration
@@ -67,7 +74,8 @@ This approach offers several advantages:
 
 ### Alternative: Configuration in YAML
 
-While not recommended for production applications, you can also specify the version directly in the configuration file. The default configuration file is located at `config/app_version.yml`:
+While not recommended for production applications, you can also specify the version directly in the configuration file.
+The default configuration file is located at `config/app_version.yml`:
 
 ```yaml
 shared:
@@ -79,7 +87,8 @@ shared:
   environment: <%= ENV.fetch('RAILS_APP_ENV', Rails.env) %>
 ```
 
-You can customize this configuration for different environments, though we recommend maintaining version information in the VERSION file:
+You can customize this configuration for different environments, though we recommend maintaining version information in
+the VERSION file:
 
 ```yaml
 shared:
@@ -101,30 +110,82 @@ staging:
 
 ```ruby
 # Get the current version
-Rails.application.version.to_s          # => "1.2.3"
+Rails.application.version.to_s # => "1.2.3"
 
 # Check version components
-Rails.application.version.major         # => 1
-Rails.application.version.minor         # => 2
-Rails.application.version.patch         # => 3
+Rails.application.version.major # => 1
+Rails.application.version.minor # => 2
+Rails.application.version.patch # => 3
 
 # Check version status
-Rails.application.version.production_ready?  # => true
-Rails.application.version.prerelease?       # => false
+Rails.application.version.production_ready? # => true
+Rails.application.version.prerelease? # => false
 
 # Get a cache-friendly version string
-Rails.application.version.to_cache_key  # => "1-2-3"
+Rails.application.version.to_cache_key # => "1-2-3"
 ```
+
+## Version Headers Middleware
+
+Rails AppVersion includes an optional middleware that adds version and environment information to HTTP response headers.
+This is particularly useful in staging and development environments to verify deployment success and track which version
+of the application is serving requests.
+
+### Configuring the Middleware
+
+Enable and configure the middleware in your `config/app_version.yml`:
+
+```yaml
+development:
+  middleware:
+    enabled: true
+    options:
+      include_revision: true  # Include git revision in headers
+      version_header: X-App-Version
+      environment_header: X-App-Environment
+      revision_header: X-App-Revision
+
+staging:
+  middleware:
+    enabled: true
+    options:
+      version_header: X-Staging-Version
+      environment_header: X-Staging-Environment
+```
+
+### Manual Middleware Configuration
+
+You can also add the middleware manually in your application configuration:
+
+```ruby
+# config/application.rb or config/environments/staging.rb
+config.middleware.use RailsAppVersion::AppInfoMiddleware, {
+  version_header: 'X-Custom-Version',
+  environment_header: 'X-Custom-Environment',
+  include_revision: true
+}
+```
+
+The middleware will add the following headers to each response:
+
+- X-App-Version: Current application version, optionally including revision (e.g., "1.2.3" or "1.2.3 (abc123de)")
+- X-App-Environment: Current environment (e.g., "staging")
+
+When `include_revision` is enabled, the version header will include the first 8 characters of the git revision in
+parentheses. This provides a quick way to verify both the version and the specific deployment in a single header.
+
+This makes it easy for developers to verify which version is deployed and running in each environment, particularly
+useful during deployments and debugging.
 
 ### Environment Management
 
 ```ruby
 # Get the current environment
-Rails.application.env                   # => "staging"
+Rails.application.env # => "staging"
 
 # Environment checks
-Rails.application.env.production?       # => false
-Rails.application.env.staging?         # => true
+Rails.application.env.production? # => false
+Rails.application.env.staging? # => true
 ```
 
 ### Console Integration
@@ -147,7 +208,41 @@ Rails AppVersion supports several version formats:
 - Short versions: "1.2" (major.minor)
 - Pre-release versions: "2.0.0-alpha" (with pre-release identifier)
 
-Version strings are parsed according to Semantic Versioning principles and maintain compatibility with `Gem::Version` for comparison operations.
+Version strings are parsed according to Semantic Versioning principles and maintain compatibility with `Gem::Version`
+for comparison operations.
+
+## Version Headers
+
+Enable version headers in HTTP responses to verify deployments and track running versions:
+
+```yaml
+# config/app_version.yml
+development:
+  middleware:
+    enabled: true
+    options:
+      include_revision: true
+
+staging:
+  middleware:
+    enabled: true
+```
+
+Or add the middleware manually:
+
+```ruby
+# config/application.rb
+config.middleware.use RailsAppVersion::AppInfoMiddleware, {
+  version_header: 'X-App-Version',
+  environment_header: 'X-App-Environment',
+  include_revision: true
+}
+```
+
+Headers added:
+
+- X-App-Version: "1.2.3" (or "1.2.3 (abc123de)" with revision)
+- X-App-Environment: "production"
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,168 @@
 # Rails AppVersion
 
-Rails AppVersion is a Ruby on Rails engine designed to easily manage and access your application's version and environment information. 
+Rails AppVersion provides seamless version and environment management for your Rails applications. By exposing version and environment information throughout your application, it enables better error tracking, debugging, and deployment management.
 
-It allows for a seamless integration of versioning within your Rails application, providing a straightforward way to access the current application version and environment without hardcoding these values.
+## Why Use Rails AppVersion?
 
-This gem is exclusively build for Rails applications and is compatible with Rails 7.0 and above.
+Version and environment tracking are crucial for modern web applications, particularly when debugging issues in production. Rails AppVersion helps you:
 
-## Usage
-How to use my plugin.
+- Track errors with version context in error reporting services
+- Identify which version of your application is running in each environment
+- Cache bust assets between versions
+- Verify deployment success across environments
+
+### Error Reporting Integration Example
+
+```ruby
+Sentry.init do |config|
+  config.release = Rails.application.version.to_s
+  config.environment = Rails.application.env
+end
+```
+
+### Cache Management Example
+
+```ruby
+class AssetManifest
+  def asset_path(path)
+    "/assets/#{path}?v=#{Rails.application.version.to_cache_key}"
+  end
+end
+```
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
 gem "rails_app_version"
 ```
 
-And then execute:
+Then execute:
+
 ```bash
-$ bundle
+$ bundle install
+$ rails app:version:config  # Copies the default configuration file
+$ echo "1.0.0" > VERSION            # Create initial version file
 ```
 
-## Usage:
-    After adding the gem, you can access the application version and environment information anywhere in your Rails application.
+## Version Management
+
+Rails AppVersion supports two methods for managing your application's version:
+
+### Recommended: Using a VERSION File
+
+The recommended approach is to maintain a `VERSION` file in your application's root directory. This file should contain only the version number:
+
+```plaintext
+# VERSION
+1.2.3
+```
+
+This approach offers several advantages:
+- Clear version history in source control
+- Easy automated updates during deployment
+- Separation of version from configuration
+- Compatibility with CI/CD pipelines
+
+### Alternative: Configuration in YAML
+
+While not recommended for production applications, you can also specify the version directly in the configuration file. The default configuration file is located at `config/app_version.yml`:
+
+```yaml
+shared:
+  # Attempts to read from VERSION file, falls back to '0.0.0'
+  version: <%= Rails.root.join('VERSION').read.strip rescue '0.0.0' %>
+  # Attempts to read from REVISION file, then tries git commit hash, finally falls back to '0'
+  revision: <%= Rails.root.join('REVISION').read.strip rescue (`git rev-parse HEAD`.strip rescue '0') %>
+  show_revision: <%= Rails.env.local? %>
+  environment: <%= ENV.fetch('RAILS_APP_ENV', Rails.env) %>
+```
+
+You can customize this configuration for different environments, though we recommend maintaining version information in the VERSION file:
+
+```yaml
+shared:
+  # Not recommended: hardcoding version in YAML
+  version: '1.2.3'
+  environment: production
+
+development:
+  environment: local
+  show_revision: true
+
+staging:
+  environment: staging
+```
+
+## Usage
+
+### Accessing Version Information
+
 ```ruby
-Rails.application.version # => "1.0.0"
-Rails.application.env # => "staging"
+# Get the current version
+Rails.application.version.to_s          # => "1.2.3"
+
+# Check version components
+Rails.application.version.major         # => 1
+Rails.application.version.minor         # => 2
+Rails.application.version.patch         # => 3
+
+# Check version status
+Rails.application.version.production_ready?  # => true
+Rails.application.version.prerelease?       # => false
+
+# Get a cache-friendly version string
+Rails.application.version.to_cache_key  # => "1-2-3"
 ```
 
-## Features
-- Easy Configuration: Set up your application version and environment in a simple YAML file.
-- Automatic Integration: The engine automatically integrates with your Rails application, making the version and environment information accessible.
-- Flexible Usage: Access the application version and environment information anywhere in your Rails application.
+### Environment Management
+
+```ruby
+# Get the current environment
+Rails.application.env                   # => "staging"
+
+# Environment checks
+Rails.application.env.production?       # => false
+Rails.application.env.staging?         # => true
+```
+
+### Console Integration
+
+The gem automatically displays version and environment information when you start a Rails console:
+
+```
+Welcome to the Rails console!
+Ruby version: 3.2.0
+Application environment: staging
+Application version: 1.2.3
+To exit, press `Ctrl + D`.
+```
+
+## Version Format
+
+Rails AppVersion supports several version formats:
+
+- Standard versions: "1.2.3" (major.minor.patch)
+- Short versions: "1.2" (major.minor)
+- Pre-release versions: "2.0.0-alpha" (with pre-release identifier)
+
+Version strings are parsed according to Semantic Versioning principles and maintain compatibility with `Gem::Version` for comparison operations.
 
 ## Contributing
-Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
-1. Fork the repo
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
-5. Create a new Pull Request
+
+We welcome contributions! Here's how you can help:
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Add tests for your changes
+4. Make your changes and ensure tests pass
+5. Commit your changes (`git commit -am 'Add some feature'`)
+6. Push to the branch (`git push origin my-new-feature`)
+7. Create a new Pull Request
+
+Please ensure your changes include appropriate tests and documentation.
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/gemfiles/r7.gemfile
+++ b/gemfiles/r7.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "railties", "~> 7.0"
 gem "rubocop-rails-omakase", require: false
 gem "dotenv-rails", require: "dotenv/load"
+gem "mocha", "~> 2.7"
 
 gemspec path: "../"

--- a/gemfiles/r71.gemfile
+++ b/gemfiles/r71.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "railties", "~> 7.1"
 gem "rubocop-rails-omakase", require: false
 gem "dotenv-rails", require: "dotenv/load"
+gem "mocha", "~> 2.7"
 
 gemspec path: "../"

--- a/gemfiles/r72.gemfile
+++ b/gemfiles/r72.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "railties", "~> 7.2.0"
 gem "rubocop-rails-omakase", require: false
 gem "dotenv-rails", require: "dotenv/load"
+gem "mocha", "~> 2.7"
 
 gemspec path: "../"

--- a/gemfiles/r8.gemfile
+++ b/gemfiles/r8.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "railties", "~> 8.0.0"
 gem "rubocop-rails-omakase", require: false
 gem "dotenv-rails", require: "dotenv/load"
+gem "mocha", "~> 2.7"
 
 gemspec path: "../"

--- a/lib/rails_app_version.rb
+++ b/lib/rails_app_version.rb
@@ -10,53 +10,9 @@ require "rails_app_version/version"
 require "action_controller/railtie"
 
 module RailsAppVersion
-  class Version < Gem::Version
-    attr_reader :major, :minor, :patch, :pre
+  extend ActiveSupport::Autoload
 
-    def initialize(version_string)
-      super
-      parse_version(version_string)
-    end
-
-    def to_cache_key
-      parts = [ major, minor ]
-      parts << patch if has_patch?
-      parts << pre if prerelease?
-      parts.join("-")
-    end
-
-    def prerelease?
-      !@pre.nil?
-    end
-
-    def production_ready?
-      !prerelease? && major.positive?
-    end
-
-    def has_patch?
-      !@patch.nil?
-    end
-
-    private
-
-    def parse_version(version_string)
-      if version_string.nil? || version_string.empty?
-        raise ArgumentError, "Version string cannot be nil or empty"
-      end
-
-      parts = version_string.split(".")
-      pre_parts = parts.last.split("-")
-
-      if pre_parts.length > 1
-        parts[-1] = pre_parts[0]
-        @pre = pre_parts[1]
-      end
-
-      @major = parts[0].to_i
-      @minor = parts[1]&.to_i || 0
-      @patch = parts[2]&.to_i
-    end
-  end
+  autoload :AppInfoMiddleware
 end
 
 Rails::Application.include RailsAppVersion::AppVersion

--- a/lib/rails_app_version/app_info_middleware.rb
+++ b/lib/rails_app_version/app_info_middleware.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RailsAppVersion
+  class AppInfoMiddleware
+    DEFAULT_OPTIONS = {
+      version_header: "X-App-Version",
+      environment_header: "X-App-Environment",
+      revision_header: "X-App-Revision",
+      include_revision: false
+    }.freeze
+
+    def initialize(app, options = {})
+      @app = app
+      @options = DEFAULT_OPTIONS.merge(options)
+    end
+
+    def call(env)
+      status, headers, response = @app.call(env)
+
+      headers[@options[:version_header]] = Rails.application.version.full
+      headers[@options[:environment_header]] = Rails.application.env
+
+      [ status, headers, response ]
+    end
+  end
+end

--- a/lib/rails_app_version/railtie.rb
+++ b/lib/rails_app_version/railtie.rb
@@ -39,15 +39,14 @@ module RailsAppVersion
       @app_config = begin
                       app.config_for(:app_version, env: Rails.env)
                     rescue RuntimeError => e # file is not found
-                      # Load the default configuration from the gem, if the app does not have one
+                      # Load the default configuration from the gem
                       require "erb"
-
                       yaml = Railtie.root.join("config", "app_version.yml")
                       all_configs = ActiveSupport::ConfigurationFile.parse(yaml).deep_symbolize_keys
                       all_configs[:shared]
                     end
 
-      @version = Version.new(@app_config[:version])
+      @version = RailsAppVersion::Version.create(@app_config[:version], @app_config[:revision])
       @env = ActiveSupport::StringInquirer.new(@app_config.fetch(:environment, Rails.env))
     end
   end

--- a/lib/rails_app_version/version.rb
+++ b/lib/rails_app_version/version.rb
@@ -2,4 +2,71 @@
 
 module RailsAppVersion
   VERSION = "1.1.1"
+
+  class Version < Gem::Version
+    attr_reader :major, :minor, :patch, :pre, :revision
+
+    def self.create(version_string, revision = nil)
+      new(version_string).tap { |v| v.set_revision(revision) }
+    end
+
+    def set_revision(revision)
+      @revision = revision
+    end
+
+    def full
+      return to_s unless revision
+      "#{self} (#{short_revision})"
+    end
+
+    def to_cache_key
+      parts = [ major, minor ]
+      parts << patch if has_patch?
+      parts << pre if prerelease?
+      parts.join("-")
+    end
+
+    def short_revision
+      revision&.slice(0, 8)
+    end
+
+    def prerelease?
+      !@pre.nil?
+    end
+
+    def production_ready?
+      !prerelease? && major.positive?
+    end
+
+    def has_patch?
+      !@patch.nil?
+    end
+
+    protected
+
+    def initialize(version)
+      super
+      parse_version(version)
+    end
+
+    private
+
+    def parse_version(version_string)
+      if version_string.nil? || version_string.empty?
+        raise ArgumentError, "Version string cannot be nil or empty"
+      end
+
+      parts = version_string.split(".")
+      pre_parts = parts.last.split("-")
+
+      if pre_parts.length > 1
+        parts[-1] = pre_parts[0]
+        @pre = pre_parts[1]
+      end
+
+      @major = parts[0].to_i
+      @minor = parts[1]&.to_i || 0
+      @patch = parts[2]&.to_i
+    end
+  end
 end

--- a/rails_app_version.gemspec
+++ b/rails_app_version.gemspec
@@ -3,12 +3,12 @@
 require_relative 'lib/rails_app_version/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'rails_app_version'
-  spec.version     = RailsAppVersion::VERSION
-  spec.authors     = [ 'Abdelkader Boudih' ]
-  spec.email       = [ 'terminale@gmail.com' ]
-  spec.homepage    = 'https://github.com/seuros/rails_app_version'
-  spec.summary     = 'Get the version of your Rails app'
+  spec.name = 'rails_app_version'
+  spec.version = RailsAppVersion::VERSION
+  spec.authors = [ 'Abdelkader Boudih' ]
+  spec.email = [ 'terminale@gmail.com' ]
+  spec.homepage = 'https://github.com/seuros/rails_app_version'
+  spec.summary = 'Get the version of your Rails app'
   spec.description = spec.summary
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/test/app_info_middleware_test.rb
+++ b/test/app_info_middleware_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RailsAppVersion
+  class AppInfoMiddlewareTest < ActiveSupport::TestCase
+    def setup
+      @app = ->(env) { [ 200, {}, [ "OK" ] ] }
+      @version = Version.create("8.0.3", "abc123def456")
+      @env = "sandbox"
+
+      Rails.application.stubs(:version).returns(@version)
+      Rails.application.stubs(:env).returns(@env)
+    end
+
+    def teardown
+      Rails.application.unstub(:version)
+      Rails.application.unstub(:env)
+    end
+
+    test "adds default version and environment headers" do
+      middleware = AppInfoMiddleware.new(@app)
+      status, headers, response = middleware.call({})
+
+      assert_equal "8.0.3 (abc123de)", headers["X-App-Version"]
+      assert_equal "sandbox", headers["X-App-Environment"]
+      assert_equal 200, status
+      assert_equal [ "OK" ], response
+    end
+
+    test "allows custom header names" do
+      middleware = AppInfoMiddleware.new(@app, {
+        version_header: "X-Custom-Version",
+        environment_header: "X-Custom-Environment"
+      })
+
+      _, headers, _ = middleware.call({})
+
+      assert_equal "8.0.3 (abc123de)", headers["X-Custom-Version"]
+      assert_equal "sandbox", headers["X-Custom-Environment"]
+    end
+
+    test "includes revision in version header when configured" do
+      middleware = AppInfoMiddleware.new(@app, {
+        include_revision: true
+      })
+
+      _, headers, _ = middleware.call({})
+
+      assert_equal "8.0.3 (abc123de)", headers["X-App-Version"]
+    end
+
+    test "ignores include_revision when version has no revision" do
+      version_without_revision = Version.create("8.0.3")
+      Rails.application.stubs(:version).returns(version_without_revision)
+
+      middleware = AppInfoMiddleware.new(@app, {
+        include_revision: true
+      })
+
+      _, headers, _ = middleware.call({})
+
+      assert_equal "8.0.3", headers["X-App-Version"]
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
+require "mocha/minitest"
 
 # load tasks
 Rails.application.load_tasks

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 module RailsAppVersion
   class VersionTest < ActiveSupport::TestCase
     def setup
-      @version_three_parts = Version.new("1.2.3")
-      @version_two_parts = Version.new("1.2")
-      @pre_version = Version.new("2.0.0-alpha")
+      @version_three_parts = Version.create("1.2.3")
+      @version_two_parts = Version.create("1.2")
+      @pre_version = Version.create("2.0.0-alpha")
+      @version_with_revision = Version.create("1.2.3", "abc123def456")
     end
 
     test "parses major and minor versions" do
@@ -37,19 +38,29 @@ module RailsAppVersion
       assert @version_three_parts.production_ready?
       assert @version_two_parts.production_ready?
       assert_not @pre_version.production_ready?
-      assert_not Version.new("0.1.0").production_ready?
+      assert_not Version.create("0.1.0").production_ready?
     end
 
-    test "generates cache keys" do
-      assert_equal "1-2-3", @version_three_parts.to_cache_key
+    test "provides standard version string without revision" do
+      assert_equal "1.2.3", @version_with_revision.to_s
+    end
+
+    test "includes revision only in full version string" do
+      assert_equal "1.2.3 (abc123de)", @version_with_revision.full
+    end
+
+    test "generates cache key without revision" do
+      assert_equal "1-2-3", @version_with_revision.to_cache_key
       assert_equal "1-2", @version_two_parts.to_cache_key
       assert_equal "2-0-0-alpha", @pre_version.to_cache_key
     end
 
     test "maintains compatibility with Gem::Version comparison" do
-      assert Version.new("2.0") > Version.new("1.9")
-      assert Version.new("1.2") < Version.new("1.2.1")
-      assert Version.new("1.2.0") == Version.new("1.2")
+      assert Version.create("2.0") > Version.create("1.9")
+      assert Version.create("1.2") < Version.create("1.2.1")
+      assert Version.create("1.2.0") == Version.create("1.2")
+      # Revision should not affect comparison
+      assert Version.create("1.2.0", "abc") == Version.create("1.2.0", "def")
     end
   end
 end


### PR DESCRIPTION
Add optional middleware to expose version and environment information in HTTP
headers. This helps track deployed versions and verify successful deployments.

- Add AppInfoMiddleware with configurable headers
- Allow enabling via config/app_version.yml or manual configuration
- Support showing git revision in version header
- Add test coverage