### PR TITLE
feat: add support for Rails 8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -41,7 +41,7 @@ jobs:
           - r81
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/Appraisals
+++ b/Appraisals
@@ -15,5 +15,5 @@ appraise "r8" do
 end
 
 appraise "r81" do
-  gem "railties", github: "rails/rails"
+  gem "railties", "~> 8.1.0"
 end

--- a/gemfiles/r81.gemfile
+++ b/gemfiles/r81.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "railties", github: "rails/rails"
+gem "railties", "~> 8.1.0"
 gem "rubocop-rails-omakase", require: false
 gem "dotenv-rails", require: "dotenv/load"
 gem "mocha", "~> 2.7"

--- a/rails_app_version.gemspec
+++ b/rails_app_version.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     Dir['{config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'railties', '>= 7.0', '< 8.1'
+  spec.add_dependency 'railties', '>= 7.0', '< 8.2'
   spec.add_development_dependency 'dotenv-rails'
   spec.add_development_dependency "appraisal"
 end


### PR DESCRIPTION
## Summary
- Updates railties dependency constraint from `< 8.1` to `< 8.2` to properly support Rails 8.1.0
- Changes r81 appraisal from edge Rails (github) to stable release `~> 8.1.0`
- Regenerates gemfiles to use the released version
- Updates GitHub Actions checkout to v5

## Context
Rails 8.1.0 was officially released. The gem was previously blocking it with the `< 8.1` constraint in the gemspec, despite the changelog mentioning support was added in v1.3.0.

## Test plan
- [x] CI will automatically test against Rails 8.1.0 via the existing r81 job
- [x] All other Rails versions (7.0, 7.1, 7.2, 8.0) remain supported